### PR TITLE
Various manifest fixes

### DIFF
--- a/codecs/ffmpeg.json
+++ b/codecs/ffmpeg.json
@@ -1,13 +1,14 @@
 {
     "name": "ffmpeg",
+    "build-options": {
+        "prefix": "/app/lib/codecs/"
+    },
     "cleanup": [
       "/lib/codecs/share/ffmpeg/examples",
       "/lib/codecs/lib/pkgconfig",
       "/lib/codecs/include"
     ],
     "config-opts": [
-        "--prefix=/app/lib/codecs/",
-        "--libdir=/app/lib/codecs/lib",
         "--disable-debug",
         "--disable-doc",
         "--disable-static",

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -27,7 +27,7 @@
         /* Access DVDs */
         "--filesystem=/run/media",
         /* Browse gvfs */
-        "--talk-name=org.gtk.vfs", "--talk-name=org.gtk.vfs.*",
+        "--talk-name=org.gtk.vfs.*",
         "--filesystem=xdg-run/gvfs", "--filesystem=xdg-run/gvfsd",
         /* screensaver plugin */
         "--talk-name=org.gnome.ScreenSaver",

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -199,7 +199,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/tracker.git",
-                    "branch": "tracker-3.2",
+                    /* branch is tracker-3.2 */
                     "commit": "bacc2d4172f5fd3791a47f563e336fd48c6ef51e"
                 }
             ]


### PR DESCRIPTION
- Fix the use of prefix for ffmpeg: the build produced is identical. See https://github.com/flathub/flatpak-builder-lint/issues/53
- Remove unecessary dbus for gvfs. See https://github.com/flathub/flathub/issues/2180#issuecomment-811984901
- Remove the branch for tracker. There already was a commit. Branch + commit will fail.

The build might still not pass the linter.
