### PR TITLE
Fix tracker crasher

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -199,8 +199,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/tracker.git",
-                    "branch": "tracker-3.2",
-                    "commit": "bacc2d4172f5fd3791a47f563e336fd48c6ef51e"
+                    "tag": "3.4.1"
                 }
             ]
         },
@@ -223,7 +222,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/tracker-miners.git",
-                    "tag": "3.2.1"
+                    "tag": "3.4.1"
                 }
             ]
         },


### PR DESCRIPTION
tracker-miners-3 would crash with a SIGSYS on startup.

See https://gitlab.gnome.org/GNOME/tracker-miners/-/merge_requests/419