### PR TITLE
flatpak: Disable libpeas-gtk

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -79,6 +79,7 @@
         {
             "name": "libpeas",
             "buildsystem": "meson",
+            "config-opts": [ "-Dwidgetry=false" ],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
We don't need libpeas-gtk anymore so let's disable it.