### PR TITLE
Add fix for black screen on new Radeon

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -47,7 +47,9 @@
         /* totem-pl-parser extension */
         "--env=PATH=/app/lib/totem-pl-parser/bin/:/app/lib/codecs/bin/:/app/bin:/usr/bin",
         "--env=TOTEM_PL_PARSER_VIDEOSITE_SCRIPT_DIR=/app/lib/totem-pl-parser/bin/",
-        "--env=PYTHONPATH=/app/lib/totem-pl-parser/site-packages"
+        "--env=PYTHONPATH=/app/lib/totem-pl-parser/site-packages",
+        /* Disable glthread, see mesa #7948 */
+        "--env=mesa_glthread=false"
     ],
     "add-extensions": {
         "org.gnome.Totem.Devel.Codecs": {


### PR DESCRIPTION
Build our own GTK+ 3.x to fix a black screen video on systems with Radeon hardware and newer versions of Mesa.

See: https://gitlab.gnome.org/GNOME/gtk/-/issues/5517