### PR TITLE
Include gstopenh264 in main app

### DIFF
--- a/codecs/gstreamer.json
+++ b/codecs/gstreamer.json
@@ -17,7 +17,6 @@
         "-Dlibav=enabled",
         "-Dbad=enabled",
         "-Dvaapi=disabled",
-        "-Dgst-plugins-bad:openh264=disabled",
         "-Dgst-plugins-bad:vulkan=disabled",
         "-Dgst-plugins-bad:va=enabled",
         "-Dugly=enabled",

--- a/codecs/move-gst-plugins.sh
+++ b/codecs/move-gst-plugins.sh
@@ -5,7 +5,8 @@ export GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0
 export LD_LIBRARY_PATH=/app/lib/codecs/lib/:/app/lib/
 
 for i in /app/lib/gstreamer-1.0/*.so; do
-  if [ ${i##*/} == 'libgstfdkaac.so' ]; then
+  if [ ${i##*/} == 'libgstfdkaac.so' ] ||
+     [ ${i##*/} == 'libgstopenh264.so' ]; then
     continue
   fi
 

--- a/codecs/move-gst-plugins.sh
+++ b/codecs/move-gst-plugins.sh
@@ -5,6 +5,10 @@ export GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0
 export LD_LIBRARY_PATH=/app/lib/codecs/lib/:/app/lib/
 
 for i in /app/lib/gstreamer-1.0/*.so; do
+  if [ ${i##*/} == 'libgstfdkaac.so' ]; then
+    continue
+  fi
+
   SUITE=`gst-inspect-1.0 $i | grep "Source module" | sed 's,Source module,,' | tr -d [:blank:]`
   if [ x$SUITE == x'gst-plugins-bad' ] ||
      [ x$SUITE == x'gst-plugins-ugly' ] ||


### PR DESCRIPTION
See https://github.com/flathub/org.gnome.Totem.Devel/issues/25.

This is based on #26.

TODO:

- [ ] gstopenh264 can decode (some) H.264 bitstreams but it doesn't seem to be able to parse the format by itself. But `h264parse` is in `.Codecs`.
- [x] When I tested my sample file with a simple `gst-launch-1.0` pipeline using openh264 elsewhere, playback was not smooth. But when I test it in my test build of this branch (also hacking more elements into place), it is smooth. I do not understand why the difference so I am doing some more research :)
    - I had just left the `queue` out of my pipeline.