### PR TITLE
Include most of gst-plugins-bad, including gstopenh264, in main app

### DIFF
--- a/codecs/move-gst-plugins.sh
+++ b/codecs/move-gst-plugins.sh
@@ -1,15 +1,39 @@
-#!/bin/sh
+#!/bin/bash
 
 mkdir -p /app/lib/codecs/lib/gstreamer-1.0
+
+SYSTEM_MODULES_DIR=$(PKG_CONFIG_PATH='' pkg-config --variable=pluginsdir gstreamer-1.0)
 export GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0
 export LD_LIBRARY_PATH=/app/lib/codecs/lib/:/app/lib/
 
 for i in /app/lib/gstreamer-1.0/*.so; do
-  SUITE=`gst-inspect-1.0 $i | grep "Source module" | sed 's,Source module,,' | tr -d [:blank:]`
-  if [ x$SUITE == x'gst-plugins-bad' ] ||
-     [ x$SUITE == x'gst-plugins-ugly' ] ||
-     [ x$SUITE == x'gst-libav' ]; then
-    mv $i /app/lib/codecs/lib/gstreamer-1.0
-  fi
-done
+  while read -r line
+  do
+    case "$line" in
+      "Source module"*)
+        SUITE="$(echo "$line" | sed 's,Source module,,' | tr -d '[:blank:]')"
+        ;;
+      Name*)
+        PLUGIN="$(echo "$line" | sed 's,Name,,' | tr -d '[:blank:]')"
+        ;;
+    esac
+  done < <(gst-inspect-1.0 "$i")
 
+
+  case "$SUITE" in
+    gst-plugins-ugly|gst-libav)
+      echo "Exiling $PLUGIN from $SUITE to codecs runtime" >&2
+      mv "$i" /app/lib/codecs/lib/gstreamer-1.0
+      ;;
+
+    gst-plugins-bad)
+      if [ -e "$SYSTEM_MODULES_DIR/$(basename "$i")" ]
+      then
+        echo "Keeping $PLUGIN from $SUITE (present in runtime) in app" >&2
+      else
+        echo "Exiling $PLUGIN from $SUITE to codecs runtime" >&2
+        mv "$i" /app/lib/codecs/lib/gstreamer-1.0
+      fi
+      ;;
+  esac
+done


### PR DESCRIPTION
As outlined in the two commit messages, this doesn't increase the encumbered-codec surface area of the main app because all this code is already present in its dependent runtime, if only it would use the system gstreamer.

This change makes it possible to decode many more videos on systems which do not have the `.Codecs` extension installed, but one or both of the openh264 extension or VAAPI drivers. (There are be contexts where distributors or users are comfortable installing these but not the full bundle of fancy codecs.)

Fixes https://github.com/flathub/org.gnome.Totem.Devel/issues/25