### PR TITLE
Remove sandbox holes related to the screenshot plugin

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -31,8 +31,6 @@
         "--filesystem=xdg-run/gvfs", "--filesystem=xdg-run/gvfsd",
         /* screensaver plugin */
         "--talk-name=org.gnome.ScreenSaver",
-        /* screenshot plugin */
-        "--filesystem=xdg-pictures",
         /* save-file plugin */
         "--talk-name=org.gnome.Nautilus",
         /* MPRIS plugin */

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -32,7 +32,6 @@
         /* screensaver plugin */
         "--talk-name=org.gnome.ScreenSaver",
         /* screenshot plugin */
-        "--talk-name=org.gnome.Shell",
         "--filesystem=xdg-pictures",
         /* save-file plugin */
         "--talk-name=org.gnome.Nautilus",


### PR DESCRIPTION
The `org.gnome.Shell` "Flash" has been inaccessible from apps for a number of releases, and the screenshot plugin got updated to use a filechooser instead of requiring access to the Pictures directory.