### PR TITLE
Fix physical DVD playback on Debian and derivatives

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -26,6 +26,7 @@
         "--filesystem=xdg-download",
         /* Access DVDs */
         "--filesystem=/run/media",
+        "--filesystem=/media",
         /* Browse gvfs */
         "--talk-name=org.gtk.vfs.*",
         "--filesystem=xdg-run/gvfs", "--filesystem=xdg-run/gvfsd",


### PR DESCRIPTION
Debian and derivatives like Ubuntu use /media rather than /run/media for FHS and compatibility reasons.

Allow access to /media so that physical DVDs can be played back on those distributions.

See https://github.com/storaged-project/udisks/commit/ae2a5ff1e49ae924605502ace170eb831e9c38e4