### PR TITLE
Remove liboauth dependency

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -125,18 +125,6 @@
             "cleanup": [ "/include" ]
         },
         {
-            "name": "liboauth",
-            "config-opts": [ "--enable-nss", "--enable-shared", "--disable-static" ],
-            "cleanup": [ "/bin/*oauth*", "share/man/man1/*oauth*" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://freefr.dl.sourceforge.net/project/liboauth/liboauth-1.0.3.tar.gz",
-                    "sha256": "0df60157b052f0e774ade8a8bac59d6e8d4b464058cc55f9208d72e41156811f"
-                }
-            ]
-        },
-        {
             "name": "libgdata",
             "buildsystem": "meson",
             "config-opts": [ "-Dalways_build_tests=false", "-Dgtk_doc=false", "-Dgoa=disabled" ],


### PR DESCRIPTION
It was only used in grilo-plugins if gnome-online-accounts support was enabled, but it was disabled in 61ecd700d80b ("Disable gnome-online-accounts grilo integration").