### PR TITLE
Use libsoup-3 instead of libsoup-2.4

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -65,7 +65,6 @@
     "cleanup": [ "/include", "/share/bash-completion", "/share/doc", "/lib/*.la" ],
     "modules": [
         "shared-modules/lua5.4/lua-5.4.json",
-        "shared-modules/libsoup/libsoup-2.4.json",
         "codecs/liba52.json",
         "codecs/libmpeg2.json",
         "codecs/libdv.json",
@@ -110,7 +109,7 @@
             "name": "librest",
             "buildsystem": "meson",
             "config-opts": [
-                "-Dsoup2=true"
+                "-Dsoup2=false"
             ],
             "sources": [
                 {
@@ -131,7 +130,7 @@
                 "-Denable-gtk-doc=false",
                 "-Denable-grl-net=true",
                 "-Denable-grl-pls=true",
-                "-Dsoup3=false"
+                "-Dsoup3=true"
             ],
             "sources": [
                 {
@@ -141,19 +140,6 @@
                 }
             ],
             "cleanup": [ "/include" ]
-        },
-        {
-            "name": "libgdata",
-            "buildsystem": "meson",
-            "config-opts": [ "-Dalways_build_tests=false", "-Dgtk_doc=false", "-Dgoa=disabled" ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/libgdata.git",
-                    "commit": "6fd85102e7dcf7414000264a263465ba5cb894e4",
-                    "tag": "0.17.12"
-                }
-            ]
         },
         {
             "name": "gom",
@@ -265,7 +251,7 @@
             "config-opts": [
                 "-Denable-filesystem=yes",
                 "-Denable-optical-media=yes",
-                "-Denable-youtube=yes",
+                "-Denable-youtube=no",
                 "-Denable-bookmarks=yes",
                 "-Denable-lua-factory=yes",
                 "-Denable-metadata-store=yes",


### PR DESCRIPTION
By building grilo against libsoup-3 and removing the unported libgdata dependency. This will disable the youtube plugin in grilo-plugins, but seeing as we didn't have a use for it apart from the "search" drop-down, not a big loss.